### PR TITLE
Fix for bug caused when locale variable is set to None

### DIFF
--- a/bootstrap_markdown/widgets.py
+++ b/bootstrap_markdown/widgets.py
@@ -29,8 +29,10 @@ class MarkdownEditor(forms.Textarea):
             locale = 'bootstrap_markdown/locale/bootstrap-markdown.{}.js'\
                 .format(markdown_config['locale'])
             opts['locale'] = markdown_config['locale']
+        else:
+            locale = None
 
         return mark_safe(render_to_string('bootstrap_markdown/base_widget.html',
             {'boostrap_cdn': boostrap_cdn, 'locale': locale,
-            'id': name, 'opts': opts,
+            'id': self.attrs['id'], 'opts': opts,
             'element': super(MarkdownEditor, self).render(name, value, attrs)}))


### PR DESCRIPTION
When I left the locale variable in settings.py for my project set to none, I received and UnboundLocalError. A look at the code lead me to the conclusion that if locale is set to None in settings.py, the local variable named locale widgets.py will never be set. I have added an else statement to widgets.py to handle such a scenario.
