### PR TITLE
Fixed fullscreen option

### DIFF
--- a/bootstrap_markdown/templates/bootstrap_markdown/base_widget.html
+++ b/bootstrap_markdown/templates/bootstrap_markdown/base_widget.html
@@ -19,7 +19,7 @@ $(document).ready(function() {
     iconlibrary: "{{ opts.icon }}",
     {% if opts.locale %}language: "{{ opts.locale }}",{% endif %}
     footer: "{{ opts.footer }}",
-    fullscreen: {{ opts.fullscreen }}
+    fullscreen: { enable: {{ opts.fullscreen }} }
     };
     $('#{{ id }}').markdown(opts);
 });


### PR DESCRIPTION
The bootstrap-markdown plugin (v2.8.0) uses the option 'fullscreen' as an object. And to have it enabled, need to set the property 'enabled' to true, or false if wants to disable.
